### PR TITLE
Support for PlatformIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.pioenvs
+.piolibdeps
+.clang_complete
+.gcc-flags.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
-[submodule "lib/pubsubclient"]
-	path = lib/pubsubclient
-	url = https://github.com/knolleary/pubsubclient.git
 [submodule "lib/ESP8266wifi"]
 	path = lib/ESP8266wifi
 	url = https://github.com/ekstrand/ESP8266wifi
+[submodule "lib/PubSubClient"]
+	path = lib/PubSubClient
+	url = https://github.com/knolleary/pubsubclient.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,65 @@
-# Choose Language, We're going to use GUI arduino IDE hence this doesn't matter
-language: c
+# Continuous Integration (CI) is the practice, in software
+# engineering, of merging all developer working copies with a shared mainline
+# several times a day < http://docs.platformio.org/page/ci/index.html >
+#
+# Documentation:
+#
+# * Travis CI Embedded Builds with PlatformIO
+#   < https://docs.travis-ci.com/user/integration/platformio/ >
+#
+# * PlatformIO integration with Travis CI
+#   < http://docs.platformio.org/page/ci/travis.html >
+#
+# * User Guide for `platformio ci` command
+#   < http://docs.platformio.org/page/userguide/cmd_ci.html >
+#
+#
+# Please choice one of the following templates (proposed below) and uncomment
+# it (remove "# " before each line) or use own configuration according to the
+# Travis CI documentation (see above).
+#
 
-# Install Arduino IDE 1.6.11 and set build environment
-before_install:
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
-  - sleep 3
-  - export DISPLAY=:1.0
-  - wget http://downloads.arduino.cc/arduino-1.6.11-linux64.tar.xz
-  - tar xf arduino-1.6.11-linux64.tar.xz
-  - sudo mv arduino-1.6.11 /usr/local/share/arduino
-  - sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
 
-# Install ESP8266 support, Dependencies and clone repo for build
-install:
-  - arduino --pref "boardsmanager.additional.urls=http://arduino.esp8266.com/stable/package_esp8266com_index.json" --save-prefs
-  - arduino --install-boards esp8266:esp8266 --save-prefs
-  - arduino --pref "compiler.warning_level=all" --save-prefs
-#  - arduino --install-library "PubSubClient, ESP8266wifi"
-  - git clone https://github.com/knolleary/pubsubclient.git /usr/local/share/arduino/libraries/PubSubClient
-  - git clone https://github.com/ekstrand/ESP8266wifi /usr/local/share/arduino/libraries/ESP8266wifi
-  
+#
+# Template #1: General project. Test it using existing `platformio.ini`.
+#
 
-#Starts Build
-script:
-  - "echo $PWD"
-  - "ls $PWD"
-  - arduino -v --verbose-build --verify $PWD/firmware/ESP8266.ino
+# language: python
+# python:
+#     - "2.7"
+#
+# sudo: false
+# cache:
+#     directories:
+#         - "~/.platformio"
+#
+# install:
+#     - pip install -U platformio
+#
+# script:
+#     - platformio run
 
-notifications:
-  email:
-    on_success: change
-    on_failure: change
+
+#
+# Template #2: The project is intended to by used as a library with examples
+#
+
+# language: python
+# python:
+#     - "2.7"
+#
+# sudo: false
+# cache:
+#     directories:
+#         - "~/.platformio"
+#
+# env:
+#     - PLATFORMIO_CI_SRC=path/to/test/file.c
+#     - PLATFORMIO_CI_SRC=examples/file.ino
+#     - PLATFORMIO_CI_SRC=path/to/test/directory
+#
+# install:
+#     - pip install -U platformio
+#
+# script:
+#     - platformio ci --lib="." --board=ID_1 --board=ID_2 --board=ID_N

--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
-# EazyExit
-EazyExit is an open-source home automation and security solution which is focused to provide you with seamless connected home experience while ensuring security in your absence.
+# EazyExit is an open-source home automation and security solution which is focused to provide you with seamless connected home experience, while ensuring security in your absence.
+
+## Changelog:
+
+13/03/2017:
+- Added PlatformIO(http://platformio.org) development and Build support
+
+## Setting up MQTT Server/Broker (Raspberry Pi/Debian Equivalent)
+
+	- ``` sudo apt-get update ```
+	- ``` sudo apt-get install mosquito mosquito-clients```
+	- Mosquito broker will automatically start running on <your_pi_ip_address> port 1883
+
+## Setting up Development and Build system
+
+- Hardware Supported (ESP8266 Nodemcu modules).
+- Platform independent, only dependency is Python 2.7, pip installed.
+- Make sure SiLabs CP21xx USB to Serial drivers are installed.
+
+- Install and setup PlatformIO environment and command line tools
+	- ``` sudo pip install platformio ```
+
+- Clone the repo into your local machine
+	- ``` git clone https://github.com/Team-SDIoT/EazyExit.git ```
+	- ``` cd EazyExit ```
+
+- Fetch submodules/dependent libraries using:
+	- ```git submodule init```
+	- ```git submodule update```
+
+- In case that doesn’t work
+	- ``` cd lib ```
+	- ```git clone https://github.com/knolleary/pubsubclient.git PubSubClient```
+	- ```git clone https://github.com/ekstrand/ESP8266wifi ``
+
+- Edit /lib/credentials/credentials.h and add your WiFi SSID, WiFi password and IP address of server(Raspberry Pi) running MQTT broker
+
+- Edit GPIO pin number /src/ESP8266.cpp if required default is pin D0 on which on-board LED is connected
+
+- Build project using following command:
+	- ``` pio run ``` // Note: This will build and generate binaries for all supportive hardware
+	- ``` pio run -r nodemcu ``` // Note: This will build and generate binary only for nodemcu hardware
+
+- Build and flash directly to the board using following command:
+	- ``` pio run -e nodemcu -t upload ``` // Note: This will flash binary to board connected via USB, Serial port will be auto detected
+
+- To manually flash the binary you will need to install esptool:
+	- ``` sudo pip install esptool ```
+
+- Identify COMM port of board attached to your machine using Device Manager on windows and following command on Linux or MAC OSX
+	- ```ls /dev/tty*, on mac and linux it is /dev/tty.SLAB_USBtoUART```
+
+- cd to directory holding binary:
+	- ``` EazyExit/.pioenvs/<Targer_Board> binary —> firmware.bin```
+
+- Flash using esp_tool:
+	- ``` esptool.py -p <COMM_PORT> —baud 460800 write_flash —flash_size detect 0 firmware.bin
+## TEST
+
+- ESP node listens to MQTT messages<onn/off> on topic myHome
+- On raspberry pi run ``` mosquitto_pub -t myHome -m off ``` LED should be off and ``` mosquitto_pub -t myHome -m one ``` LED should turn on.
+
+## TODO
+- Setup continuous integration with TRAVIS CI and continuous deployment using ESP8266 OTA firmware updates.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 
 ## Setting up MQTT Server/Broker (Raspberry Pi/Debian Equivalent)
 
-	- ``` sudo apt-get update
-	-     sudo apt-get install mosquito mosquito-clients```
-- Mosquito broker will automatically start running on <your_pi_ip_address> port 1883
+	- ``` sudo apt-get update ```
+	- ``` sudo apt-get install mosquito mosquito-clients ```
+
+  - Mosquito broker will automatically start running on <your_pi_ip_address> port 1883
 
 ## Setting up Development and Build system
 
@@ -25,15 +26,15 @@
 	- ``` cd EazyExit ```
 
 - Fetch submodules/dependent libraries using:
-	- ```git submodule init```
-	- ```git submodule update```
+	- ``` git submodule init ```
+	- ``` git submodule update ```
 
 - In case that doesn’t work
 	- ``` cd lib ```
-	- ```git clone https://github.com/knolleary/pubsubclient.git PubSubClient```
-	- ```git clone https://github.com/ekstrand/ESP8266wifi ``
+	- ``` git clone https://github.com/knolleary/pubsubclient.git PubSubClient ```
+	- ``` git clone https://github.com/ekstrand/ESP8266wifi ```
 
-- Edit /lib/credentials/credentials.h and add your WiFi SSID, WiFi password and IP address of server(Raspberry Pi) running MQTT broker
+- Edit "/lib/credentials/credentials.h" and add your WiFi SSID, WiFi password and IP address of server(Raspberry Pi) running MQTT broker
 
 - Edit GPIO pin number /src/ESP8266.cpp if required default is pin D0 on which on-board LED is connected
 
@@ -54,7 +55,7 @@
 	- ``` EazyExit/.pioenvs/<Targer_Board> binary —> firmware.bin```
 
 - Flash using esp_tool:
-	- ``` esptool.py -p <COMM_PORT> —baud 460800 write_flash —flash_size detect 0 firmware.bin
+	- ``` esptool.py -p <COMM_PORT> —baud 460800 write_flash —flash_size detect 0 firmware.bin ```
 ## TEST
 
 - ESP node listens to MQTT messages<onn/off> on topic myHome

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 	- ``` git clone https://github.com/Team-SDIoT/EazyExit.git ```
 	- ``` cd EazyExit ```
 
-- Fetch submodules/dependent libraries using:
+- Fetch latest versions of submodules/dependent libraries using:
 	- ``` git submodule init ```
 	- ``` git submodule update ```
 
@@ -61,5 +61,10 @@
 - ESP node listens to MQTT messages<onn/off> on topic myHome
 - On raspberry pi run ``` mosquitto_pub -t myHome -m off ``` LED should be off and ``` mosquitto_pub -t myHome -m one ``` LED should turn on.
 
+## Development Environment setup:
+
+- Download PlatformIO official IDE "http://platformio.org/platformio-ide" or PlatformIO Plugin for ATOM IDE (http://www.atom.io)
+
 ## TODO
+
 - Setup continuous integration with TRAVIS CI and continuous deployment using ESP8266 OTA firmware updates.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 ## Setting up MQTT Server/Broker (Raspberry Pi/Debian Equivalent)
 
-	- ``` sudo apt-get update ```
-	- ``` sudo apt-get install mosquito mosquito-clients```
-	- Mosquito broker will automatically start running on <your_pi_ip_address> port 1883
+	- ``` sudo apt-get update
+	-     sudo apt-get install mosquito mosquito-clients```
+- Mosquito broker will automatically start running on <your_pi_ip_address> port 1883
 
 ## Setting up Development and Build system
 

--- a/lib/credentials/credentials.h
+++ b/lib/credentials/credentials.h
@@ -13,7 +13,7 @@
 
 //Add your WiFi and MQTT topic credentials below
 
-const char* ssid = "NEXTRA1918";
-const char* password = "pradeepkumar";
-const char* mqtt_server = "192.168.1.119"; //Address or IP
+const char* ssid = "........";
+const char* password = "........";
+const char* mqtt_server = "xxx.xxx.xxx.xxx"; //Address or IP
 const char* topic = "myHome";

--- a/lib/credentials/credentials.h
+++ b/lib/credentials/credentials.h
@@ -13,7 +13,7 @@
 
 //Add your WiFi and MQTT topic credentials below
 
-const char* ssid = "........";
-const char* password = "........";
-const char* mqtt_server = "........"; //Address or IP
+const char* ssid = "NEXTRA1918";
+const char* password = "pradeepkumar";
+const char* mqtt_server = "192.168.1.119"; //Address or IP
 const char* topic = "myHome";

--- a/lib/credentials/credentials.h
+++ b/lib/credentials/credentials.h
@@ -3,20 +3,17 @@
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
     */
 
 //Add your WiFi and MQTT topic credentials below
 
-const char* ssid = " ";
-const char* password = " ";
-const char* mqtt_server = " "; //Address or IP
+const char* ssid = "........";
+const char* password = "........";
+const char* mqtt_server = "........"; //Address or IP
 const char* topic = "myHome";

--- a/lib/readme.txt
+++ b/lib/readme.txt
@@ -1,0 +1,36 @@
+
+This directory is intended for the project specific (private) libraries.
+PlatformIO will compile them to static libraries and link to executable file.
+
+The source code of each library should be placed in separate directory, like
+"lib/private_lib/[here are source files]".
+
+For example, see how can be organized `Foo` and `Bar` libraries:
+
+|--lib
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |- readme.txt --> THIS FILE
+|- platformio.ini
+|--src
+   |- main.c
+
+Then in `src/main.c` you should use:
+
+#include <Foo.h>
+#include <Bar.h>
+
+// rest H/C/CPP code
+
+PlatformIO will find your libraries automatically, configure preprocessor's
+include paths and build them.
+
+More information about PlatformIO Library Dependency Finder
+- http://docs.platformio.org/page/librarymanager/ldf.html

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[env:esp12e]
+platform = espressif8266
+board = esp12e
+framework = arduino
+
+[env:nodemcu]
+platform = espressif8266
+board = nodemcu
+framework = arduino
+
+[env:nodemcuv2]
+platform = espressif8266
+board = nodemcuv2
+framework = arduino

--- a/src/ESP8266.cpp
+++ b/src/ESP8266.cpp
@@ -3,15 +3,12 @@
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
     */
 
 
@@ -23,15 +20,19 @@ ESP8266 firmware acting as MQTT endpoint for EazyExit home automation solution.
 
 #include <ESP8266WiFi.h>
 #include <PubSubClient.h>
-#include "credentials.h"
+#include <credentials.h>
 
 #define RELAY D0
 #define SERIAL_DEBUG 1 //Enable this for optional serial debugging
 
 
-
+//Client as instance
 WiFiClient espClient;
 PubSubClient client(espClient);
+
+//Declare functions
+void setup_wifi();
+void callback(char* , byte* , unsigned int);
 
 void setup() {
 
@@ -69,13 +70,11 @@ void setup_wifi() {
   #endif
 }
 
-
-
 void callback(char* topic, byte* payload, unsigned int length) {
 
   char p[length + 1];
   memcpy(p, payload, length);
-  p[length] = NULL;
+  p[length] = 0;
   String message(p);
 
   #if SERIAL_DEBUG
@@ -87,11 +86,9 @@ void callback(char* topic, byte* payload, unsigned int length) {
   if(message == "off")
   digitalWrite(RELAY,HIGH);
 
-
   if(message == "onn")
   digitalWrite(RELAY,LOW);
   }
-
 
 void reconnect() {
 
@@ -108,8 +105,7 @@ void reconnect() {
       Serial.println("connected");
       #endif
       client.subscribe(topic);
-
-    }
+}
 
     else {
       #if SERIAL_DEBUG


### PR DESCRIPTION
Signed-off-by: Ayan Pahwa (iayanpahwa@gmail.com)

Description: 
* Added support for PlatformIO(http://platformio.org) for future Developments and Build system
* Resolves Issue #2 

DEPENDENCIES:
* Python 2.7 and pip
* PlatformIO/pio CLI tools

TEST SUMMARY: Build Passed with PlatformIO and ESP toolchain (Note toolchain install prompt when you first build the application using pro run)

//Build Logs 
```iAyan:EazyExit iAyan$ pio run
[Tue Mar 14 00:09:18 2017] Processing esp12e (platform: espressif8266, board: esp12e, framework: arduino)
----------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
Collected 26 compatible libraries
Looking for dependencies...
Library Dependency Graph
|-- <ESP8266WiFi> v1.0
|-- <credentials>
|-- <PubSubClient> v2.6
Linking .pioenvs/esp12e/firmware.elf
Calculating size .pioenvs/esp12e/firmware.elf
Building .pioenvs/esp12e/firmware.bin
text	   data	    bss	    dec	    hex	filename
228616	   2532	  29712	 260860	  3fafc	.pioenvs/esp12e/firmware.elf
=========================================================== [SUCCESS] Took 3.66 seconds ===========================================================

[Tue Mar 14 00:09:21 2017] Processing nodemcu (platform: espressif8266, board: nodemcu, framework: arduino)
----------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
Collected 26 compatible libraries
Looking for dependencies...
Library Dependency Graph
|-- <ESP8266WiFi> v1.0
|-- <credentials>
|-- <PubSubClient> v2.6
Linking .pioenvs/nodemcu/firmware.elf
Calculating size .pioenvs/nodemcu/firmware.elf
text	   data	    bss	    dec	    hex	filename
228616	   2532	  29712	 260860	  3fafc	.pioenvs/nodemcu/firmware.elf
=========================================================== [SUCCESS] Took 1.76 seconds ===========================================================

[Tue Mar 14 00:09:23 2017] Processing nodemcuv2 (platform: espressif8266, board: nodemcuv2, framework: arduino)
----------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
Collected 26 compatible libraries
Looking for dependencies...
Library Dependency Graph
|-- <credentials>
|-- <ESP8266WiFi> v1.0
|-- <PubSubClient> v2.6
Linking .pioenvs/nodemcuv2/firmware.elf
Calculating size .pioenvs/nodemcuv2/firmware.elf
text	   data	    bss	    dec	    hex	filename
228616	   2532	  29712	 260860	  3fafc	.pioenvs/nodemcuv2/firmware.elf
=========================================================== [SUCCESS] Took 2.16 seconds ===========================================================

==================================================================== [SUMMARY] ====================================================================
Environment esp12e   	[SUCCESS]
Environment nodemcu  	[SUCCESS]
Environment nodemcuv2	[SUCCESS]
=========================================================== [SUCCESS] Took 7.58 seconds ===========================================================
iAyan:EazyExit iAyan$```

KNOWN LIMITATIONS: None