### PR TITLE
Fixed bug which always take node to WPS mode at init

### DIFF
--- a/EazyExit-Node/lib/configurations/configuration.h
+++ b/EazyExit-Node/lib/configurations/configuration.h
@@ -13,7 +13,7 @@
 
 //Add your WiFi and MQTT topic credentials below
 
-const char* ssid = "";
-const char* password = "";
+const char* ssid = "........";
+const char* password = "........";
 const char* mqtt_server = "xxx.xxx.xxx.xxx"; //Address or IP
-const char* topic = "myHome";
+const char* topic = "myHome"; // MQTT topic string

--- a/EazyExit-Node/src/ESP8266.cpp
+++ b/EazyExit-Node/src/ESP8266.cpp
@@ -128,7 +128,7 @@ void setup_wifi() {
   #endif
 
   wifi_wps_disable(); //Disable WPS mode for fallback to work
-  wifiManager.setTimeout(60); //Timeout and destroy AP after 1 minutes
+  wifiManager.setTimeout(300); //Timeout and destroy AP after 5 minutes
   wifiManager.autoConnect("EazyExit"); //Connect using WiFi manager, if no known network in range or credentials not provided
   delay(500);
 


### PR DESCRIPTION
Signed off by: Ayan Pahwa <iayanpahwa@gmail.com>

----------------------------------------------------------------------------------

Description: calling was_setup() inside setup() was the reason for the bug mentioned in #24 , it is now fixed.

Behaviour:
Priority 1: If CONFIGURATION_PROVIDED flag is enabled then it will connect to hardcoded AP
Priority 2: If CONFIGURATION_PROVIDED flag is disabled it will try to connect to known AP from EEPROM
Priority 3: If none are available go to WPS mode and try to connect via WPS protocol.
Priority 4: If WPS didn't worked use WiFi manager to fire up own AP to be used as fallback.
Priority 5: If all fails and priority 4 timeouts(5 minutes) node resets and starts init again.

----------------------------------------------------------------------------------

Limitations:
No visual notification as of now other than serial output which needs to be set using SERIAL_DEBUG flag.