### PR TITLE
Added IDENTIFY mqtt response handler.

### DIFF
--- a/EazyExit-Node/lib/configurations/configuration.h
+++ b/EazyExit-Node/lib/configurations/configuration.h
@@ -15,5 +15,5 @@
 
 const char* ssid = "........";
 const char* password = "........";
-const char* mqtt_server = "eazyexit.lan"; //Address or IP
+const char* mqtt_server = "xxx.xxx.xxx; //Address or IP
 const char* topic = "myHome"; // MQTT topic string

--- a/EazyExit-Node/src/ESP8266.cpp
+++ b/EazyExit-Node/src/ESP8266.cpp
@@ -87,8 +87,7 @@ void setup() {
       delay(1000);
       setup_wps();
       #endif
-  }
-
+}
     #if SERIAL_DEBUG
     getIP();
     #endif
@@ -110,7 +109,6 @@ void setup_wps(){
       #if SERIAL_DEBUG
       Serial.println("WPS timeout! Starting WiFi Manager");
       #endif
-
       setup_wifi();
   }
 }
@@ -123,6 +121,7 @@ bool isConnected(){
     #endif
     return false;
   }
+
   else{
     #if SERIAL_DEBUG
     Serial.println("CONNECTED TO AP");
@@ -172,6 +171,16 @@ void callback(char* topic, byte* payload, unsigned int length) {
   for(int i=0; i<=length+1; i++)
   Serial.println(message[i]);
   #endif
+
+// Send MAC ID whenever APP requests node for discovery
+  if(message == "IDENTIFY"){
+    delay(500);
+    client.publish("discoverReceive",UUID);
+    delay(500);
+    String IP = (WiFi.localIP().toString()).c_str();
+    client.publish("discoverReceive",IP.c_str());
+    client.subscribe("myHome");
+  }
 
   if(message == "OFF")
   digitalWrite(RELAY,HIGH);


### PR DESCRIPTION
Signed off By: Ayan Pahwa <iayanpahwa@gmail.com>

Description: Node responds back with sha1(MAC_ADDRESS) hash and IP address with 0.5 seconds delay when "IDENTIFY" string is published on myHome topic.

Known Limitation/Issues: Android APP to handle time syncing with Multiple Nodes hashes and IP each submitting back on same time. 

Test Summary: All test passed 